### PR TITLE
Now the buttons are only displayed when the media query matches

### DIFF
--- a/projects/auth/src/lib/components/auth/auth.component.html
+++ b/projects/auth/src/lib/components/auth/auth.component.html
@@ -1,7 +1,7 @@
 <div class="main-container">
     <div class="container" [ngClass]="{'active': showTemplate() == 'login'}">
-            <login (showRegisterForm)="changeForm($event)" [invisible]="(showForm() == 'register')" />
-            <register (showLoginForm)="changeForm($event)" [invisible]="(showForm() == 'login')"/>
+            <login (showRegisterForm)="changeForm($event)" [isSmallDevice]="isSmallDevice()" [invisible]="(showForm() == 'register')" />
+            <register (showLoginForm)="changeForm($event)" [isSmallDevice]="isSmallDevice()" [invisible]="(showForm() == 'login')"/>
 
         <!-- This component won't be needed if we're on smaller devices -->
         <toggle (changeToggle)="changeTemplate($event)" />

--- a/projects/auth/src/lib/components/auth/auth.component.ts
+++ b/projects/auth/src/lib/components/auth/auth.component.ts
@@ -22,6 +22,9 @@ export class AuthComponent implements OnInit {
     protected showTemplate = signal<'login' | 'register'>('register');
     // In smaller devices, the previous logic is managed only through the register and login components, through opacity
     protected showForm = signal<'login' | 'register'>('login');
+    protected isSmallDevice = signal(
+        window.matchMedia('(max-width: 800px)').matches
+    );
 
     constructor(private el: ElementRef) { }
 
@@ -34,6 +37,7 @@ export class AuthComponent implements OnInit {
         } else {
             this.updateTheme();
         }
+        this.startSmallerDeviceChecker();
     }
 
     private updateTheme() {
@@ -52,7 +56,6 @@ export class AuthComponent implements OnInit {
             default:
                 // return ['#372aac', '#fff', '#e5e7eb'];
                 return ['#111', '#fff', '#ddd'];
-
         }
     }
 
@@ -61,6 +64,17 @@ export class AuthComponent implements OnInit {
         // this.renderer.setStyle(hostElement, variableName, color);
         hostElement.style.setProperty(variableName, color);
     }
+
+    private startSmallerDeviceChecker() {
+        const mediaQuery = window.matchMedia('(max-width: 800px)');
+
+        const updateScreenSize = (event: MediaQueryListEvent) => {
+            this.isSmallDevice.set(event.matches);
+        };
+
+        mediaQuery.addEventListener('change', updateScreenSize);
+    }
+
     /* End logic when initialising component */
 
     /* Events logic */

--- a/projects/auth/src/lib/components/auth/subcomponents/login/login.component.html
+++ b/projects/auth/src/lib/components/auth/subcomponents/login/login.component.html
@@ -4,7 +4,7 @@
       <input class="login-input" type="email" name="email" [(ngModel)]="userInfo.email" placeholder="Email">
       <input class="login-input" type="password" name="password" [(ngModel)]="userInfo.password" placeholder="Password">
       <button class="login-button">Sign In</button>
-      @if (isSmallDevice) {
+      @if (isSmallDevice()) {
           <div class="change-text">Don’t have an account yet? <button type="submit" class="change-button" (click)="changeToSignUpForm($event)">Click here</button></div>
       }
     </form>

--- a/projects/auth/src/lib/components/auth/subcomponents/login/login.component.ts
+++ b/projects/auth/src/lib/components/auth/subcomponents/login/login.component.ts
@@ -1,19 +1,24 @@
 import { NgClass } from '@angular/common';
-import { Component, inject, input, output, signal } from '@angular/core';
+import {
+    Component,
+    inject,
+    input,
+    OnInit,
+    output,
+    signal,
+} from '@angular/core';
 import { AuthService } from '../../services/auth.service';
 import { FormsModule } from '@angular/forms';
 
 @Component({
-  selector: 'login',
-  imports: [NgClass, FormsModule],
-  templateUrl: './login.component.html',
-  styleUrl: './login.component.css'
+    selector: 'login',
+    imports: [NgClass, FormsModule],
+    templateUrl: './login.component.html',
+    styleUrl: './login.component.css',
 })
+export class LoginComponent {
+    public isSmallDevice = input<boolean>(window.matchMedia('(max-width: 800px)').matches);
 
-export class LoginComponent  {
-    // This might be changed in the future to events just in case the window screen width could change
-    // Posible solution -> BreakpointObserver
-    protected isSmallDevice = window.matchMedia("(max-width: 800px)").matches;
     public invisible = input<boolean>(false);
     protected showRegisterForm = output<'register'>();
 
@@ -34,5 +39,4 @@ export class LoginComponent  {
             localStorage.setItem('token', token);
         });
     }
-
 }

--- a/projects/auth/src/lib/components/auth/subcomponents/register/register.component.html
+++ b/projects/auth/src/lib/components/auth/subcomponents/register/register.component.html
@@ -5,7 +5,7 @@
         <input class="register-input" name="email" [(ngModel)]="userInfo.email" type="email" placeholder="Email">
         <input class="register-input" name="password" [(ngModel)]="userInfo.password" type="password" placeholder="Password">
         <button class="register-button">Sign Up</button>
-        @if (isSmallDevice) {
+        @if (isSmallDevice()) {
             <div class="change-text">Already have an account? <button class="change-button" (click)="changeToLoginForm($event)">Click here</button></div>
         }
     </form>

--- a/projects/auth/src/lib/components/auth/subcomponents/register/register.component.ts
+++ b/projects/auth/src/lib/components/auth/subcomponents/register/register.component.ts
@@ -1,5 +1,5 @@
 import { NgClass } from '@angular/common';
-import { Component, inject, input, output, signal } from '@angular/core';
+import { Component, inject, input, OnInit, output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { AuthService } from '../../services/auth.service';
 
@@ -10,7 +10,7 @@ import { AuthService } from '../../services/auth.service';
     styleUrl: './register.component.css',
 })
 export class RegisterComponent {
-    protected isSmallDevice = window.matchMedia('(max-width: 800px)').matches;
+    public isSmallDevice = input<boolean>(window.matchMedia('(max-width: 800px)').matches);
     public invisible = input<boolean>();
     protected showLoginForm = output<'login'>();
 


### PR DESCRIPTION
This was made by adding an eventListener to the media query. By doing this, we can check when does the screen width goes below or above the media query conditions. 
Each time this conditions are met, we check if the conditions match the media query or not. In this particular case, when the screen width is higher than 800px, the condition will be evaluated to false and therefore, not showing the buttons.

