### PR TITLE
fix: Now you can't get stuck in the sign up form

### DIFF
--- a/projects/auth/src/lib/components/auth/auth.component.html
+++ b/projects/auth/src/lib/components/auth/auth.component.html
@@ -1,9 +1,13 @@
 <div class="main-container">
     <div class="container" [ngClass]="{'active': showTemplate() == 'login'}">
-            <login (showRegisterForm)="changeForm($event)" [isSmallDevice]="isSmallDevice()" [invisible]="(showForm() == 'register')" />
-            <register (showLoginForm)="changeForm($event)" [isSmallDevice]="isSmallDevice()" [invisible]="(showForm() == 'login')"/>
+        <login (showRegisterForm)="changeForm($event)" [isSmallDevice]="isSmallDevice()"
+            [invisible]="(showForm() == 'register')" />
+        <register (showLoginForm)="changeForm($event)" [isSmallDevice]="isSmallDevice()"
+            [invisible]="(showForm() == 'login')" />
 
         <!-- This component won't be needed if we're on smaller devices -->
-        <toggle (changeToggle)="changeTemplate($event)" />
+        @if (!isSmallDevice()) {
+            <toggle (changeToggle)="changeTemplate($event)" />
+        }
     </div>
 </div>

--- a/projects/auth/src/lib/components/auth/auth.component.ts
+++ b/projects/auth/src/lib/components/auth/auth.component.ts
@@ -70,11 +70,18 @@ export class AuthComponent implements OnInit {
 
         const updateScreenSize = (event: MediaQueryListEvent) => {
             this.isSmallDevice.set(event.matches);
+            
+            // FIXME: This should be changed to a better solution
+            this.resetFormsView();
         };
 
         mediaQuery.addEventListener('change', updateScreenSize);
     }
 
+    private resetFormsView() {
+        this.showForm.set('login');
+        this.showTemplate.set('register');
+    }
     /* End logic when initialising component */
 
     /* Events logic */


### PR DESCRIPTION
The changes made are resetting the view when the media query event changes, making the form to show the login form again, instead of the one you were currenlty in.

This would solve the issue #15 with the conditions described above.